### PR TITLE
Optimizes GLCM generation

### DIFF
--- a/sphinx/source/conf.py
+++ b/sphinx/source/conf.py
@@ -25,7 +25,7 @@ copyright = '2020, Eve-ning'
 author = 'Eve-ning'
 
 # The full version, including alpha/beta/rc tags
-release = '0.0.3'
+release = '0.0.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/sphinx/source/frmodel/base/D2/glcm2D.rst
+++ b/sphinx/source/frmodel/base/D2/glcm2D.rst
@@ -10,62 +10,67 @@ Underlying Representation
 
 The data stored isn't actually a co-occurrence matrix, instead :math:`2 * channels` ``np.ndarray``
 
-========
-Creation
-========
+=========
+Algorithm
+=========
 
----------
+-------------
+Offset Arrays
+-------------
+
 1 Channel
----------
+#########
 
 Consider the following. ::
 
-    o o o o o                      | o o o o |       <B>            | o o o o |
-    o o o o o      .get_glcm()     | o o o o |   | o o o o |  func  | o o o o |
-    o o o o o  --(by=1, axis=Y)--> | o o o o | + | o o o o |  --->  | o o o o |
-    o o o o o                      | o o o o |   | o o o o |        | o o o o |
-    o o o o o                          <A>       | o o o o |            <C>
-     Channel
+    o o o o o                      o o o o .   . . . . .          o o o o
+    o o o o o      .get_glcm()     o o o o .   . o o o o  f(a,b)  o o o o
+    o o o o o  --(by=1, axis=Y)--> o o o o . + . o o o o  ----->  o o o o
+    o o o o o                      o o o o .   . o o o o          o o o o
+    o o o o o                      . . . . .   . o o o o
+     Channel                        Array A     Array B           Array C
+     [5 x 5]                        [4 x 4]     [4 x 4]           [4 x 4]
 
 Notice that they have the same size, this allows us to use common ``numpy`` operations on it.
 
-----------
 n Channels
-----------
+##########
 
 Imagine the above, but we do that to multiple channels at once in parallel. This helps save a lot of time because
 ``numpy`` favors vectorized operations. However, it may limit some calculations.
 
-=====================
+---------------------
 Neighbour Convolution
-=====================
+---------------------
 
 In order to map these values to channels that just rely on a single cell, we have to rely on neighbour's values.
 
 Consider this::
 
-    .                 o: Centre, +: Neighbour
-    | o o o o |       | + + + x | , | x + + + | , | x x x x | , | x x x x |
-    | o o o o |       | + o + x | , | x + o + | , | x + + + | , | + + + x |
-    | o o o o |  -->  | + + + x | , | x + + + | , | x + o + | , | + o + x |
-    | o o o o |       | x x x x | , | x x x x | , | x + + + | , | + + + x |
-        <C>
-    x x x x x  =>                 Note that it's slightly off centre because of (1)
-    x o o x x  =>  | o o |
-    x o o x x  =>  | o o |
-    x x x x x  =>
-    x x x x x  =>
-    Original       Transformed
+    .              o: Centre, +: Neighbour
+    o o o o        + + + .  ,  . + + +  ,  . . . .  ,  . . . . 
+    o o o o        + o + .  ,  . + o +  ,  . + + +  ,  + + + . 
+    o o o o   -->  + + + .  ,  . + + +  ,  . + o +  ,  + o + . 
+    o o o o        . . . .  ,  . . . .  ,  . + + +  ,  + + + . 
+    Array C
+                   . . . .  +  . . . .  +  . . . .  +  . . . .
+      x = g(o, +)  . x . .  +  . . x .  +  . . . .  +  . . . .
+              -->  . . . .  +  . . . .  +  . x . .  +  . x . .
+                   . . . .  +  . . . .  +  . . . .  +  . . . .
 
+                   . . . .
+                   . x x .
+              -->  . x x .
+                   . . . .
 
 With a radius 1, we sum all of the neighbour values together to calculate a GLCM at a specific cell.
 
 To further clarify, we do not repeatedly repeat GLCM creation, we create the 2 offset arrays, multiplied by the number
 of GLCM statistics, then do a convolution at each feasible point.
 
-=============
+-------------
 Edge Cropping
-=============
+-------------
 
 We will not resort to padding due to difficulty and minimal impact on result (a small amount of pixels removed).
 
@@ -79,26 +84,50 @@ There will be edge cropping here, so take note of the following:
 Going through the example again::
 
     1) GLCM Making, by_x = 1, by_y = 1
-    o o o o o       | o o o o |       <B>            | o o o o |
-    o o o o o       | o o o o |   | o o o o |  func  | o o o o |
-    o o o o o  -->  | o o o o | + | o o o o |  --->  | o o o o |
-    o o o o o       | o o o o |   | o o o o |        | o o o o |
-    o o o o o           <A>       | o o o o |            <C>
+    o o o o o                      o o o o .   . . . . .          o o o o
+    o o o o o      .get_glcm()     o o o o .   . o o o o  f(a,b)  o o o o
+    o o o o o  --(by=1, axis=Y)--> o o o o . + . o o o o  ----->  o o o o
+    o o o o o                      o o o o .   . o o o o          o o o o
+    o o o o o                      . . . . .   . o o o o
+     Channel                        Array A     Array B           Array C
+     [5 x 5]                        [4 x 4]     [4 x 4]           [4 x 4]
 
     2) GLCM Neighbour Summation, radius = 1
-                      o: Centre, +: Neighbour
-    | o o o o |       | + + + x | , | x + + + | , | x x x x | , | x x x x |
-    | o o o o |       | + o + x | , | x + o + | , | x + + + | , | + + + x |
-    | o o o o |  -->  | + + + x | , | x + + + | , | x + o + | , | + o + x |
-    | o o o o |       | x x x x | , | x x x x | , | x + + + | , | + + + x |
-        <C>
-    x x x x x  =>                 Note that it's slightly off centre because of (1)
-    x o o x x  =>  | o o |
-    x o o x x  =>  | o o |
-    x x x x x  =>
-    x x x x x  =>
+    .              o: Centre, +: Neighbour
+    o o o o        + + + .  ,  . + + +  ,  . . . .  ,  . . . .
+    o o o o        + o + .  ,  . + o +  ,  . + + +  ,  + + + .
+    o o o o   -->  + + + .  ,  . + + +  ,  . + o +  ,  + o + .
+    o o o o        . . . .  ,  . . . .  ,  . + + +  ,  + + + .
+    Array C
+                   . . . .  +  . . . .  +  . . . .  +  . . . .
+      x = g(o, +)  . x . .  +  . . x .  +  . . . .  +  . . . .
+              -->  . . . .  +  . . . .  +  . x . .  +  . x . .
+                   . . . .  +  . . . .  +  . . . .  +  . . . .
+
+                   . . . .
+                   . x x .         x x
+              -->  . x x .  -->    x x
+                   . . . .
+                                 Array D
+                                 [2 x 2]
 
 The resultant size, if by_x = by_y, is :math:`frame.size - by - radius * 2`.
+
+------------------------
+Non-GLCM Channel Fitting
+------------------------
+
+Because GLCM slightly compresses the frame size, we need to somehow fit the other channels into a new shape.
+
+That's where Gaussian Convolution comes in.
+
+By creating a Gaussian kernel with ``scipy.signal.windows.gaussian``,
+then using a Fast Fourier Transform Convolution ``scipy.signal.fftconvolve``,
+we apply convolution to the channel axis for all other channels.
+
+This is an improvement from the previous convolution, where it just attempts to average overlapping values.
+
+**Note:** Gaussian standard deviation is controlled by ``conv_gauss_stdev``.
 
 ==========
 Statistics
@@ -125,6 +154,19 @@ Contrast
 
     Con = \sum_{x=0}^{x_n} \sum_{y=0}^{y_n} (a_{x,y} - b_{x,y})^2
 
+Implementation
+##############
+
+Assume ``rgb_a`` and ``rgb_b`` are the offset arrays.
+
+.. code-block:: python
+
+    ar = (rgb_a - rgb_b) ** 2
+    return fftconvolve(ar, np.ones(shape=[radius * 2 + 1, radius * 2 + 1, 1]), mode='valid')
+
+This one is pretty simple, we create a calculated array for every cell, then convolve over it with
+a specified ``np.ones`` kernel the size of the window.
+
 -----------
 Correlation
 -----------
@@ -138,6 +180,54 @@ Note: If :math:`std_{a,b} = 0`, then value is 1 or -1 depending on the sign.
     Corr &= \sum_{x=0}^{x_n} \sum_{y=0}^{y_n}
             \frac{a_{x,y} * b_{x,y} - {mean_{a,b}}}
                  {std_{a,b}}
+
+Implementation
+##############
+
+Assume ``rgb_a`` and ``rgb_b`` are the offset arrays.
+
+This is pretty complicated, so let's break it down into smaller parts.
+
+Variance Formula
+================
+
+Variance can be alternatively expressed as :math:`var = E(X^2) - E(X)^2`, from here we just ``sqrt`` to get
+the stdev.
+
+This alternative formula allows us to use vectorization and convolution as a solution to the problem.
+
+This can be achieved by the following code only for offset array A
+
+.. code-block:: python
+
+    conv_a = fftconvolve(rgb_a, kernel, mode='valid')
+    conv_ae = conv_a / kernel.size  # E(A)
+
+    conv_a2 = fftconvolve(rgb_a ** 2, kernel, mode='valid')
+    conv_ae2 = conv_a2 / kernel.size  # E(A^2)
+
+    conv_ae_2 = conv_ae ** 2  # E(A)^2
+    conv_stda = np.sqrt(np.abs(conv_ae2 - conv_ae_2))
+
+Correlation
+===========
+
+Correlation is then calculated like so, note that :math:`E(x)` is just the mean.
+
+:math:`Corr = (a * b - (E(a) - E(b))) / std(a) * std(b)`
+
+Error Correction
+================
+
+If either stdev are 0, we cap it to -1 or 1 depending on the numerator.
+
+This only happens if we happen to convolute a perfectly monotonous window.
+
+.. code-block:: python
+
+    with np.errstate(divide='ignore', invalid='ignore'):
+        cor = (conv_ab - (conv_ae - conv_be)) / conv_stda * conv_stdb
+        return np.nan_to_num(cor, copy=False, nan=0, neginf=-1, posinf=1)
 
 -------
 Entropy
@@ -153,3 +243,11 @@ The algorithm has to count the pairs and square them.
 
     Con = \sum_{i=0}^{i_n} \sum_{j=0}^{j_n} GLCM_{(i,j)}^2
 
+Implementation
+##############
+
+Entropy doesn't use convolution, it receives a prepared window the runs ``bin_count`` on it.
+
+For the ``bin_count``, it's then squared then summed to get entropy for the channel.
+
+**Note:** As of v0.0.4, ``bin_count`` replaces ``unique`` for performance.

--- a/sphinx/source/info/changelog.rst
+++ b/sphinx/source/info/changelog.rst
@@ -3,6 +3,15 @@ ChangeLog
 #########
 
 -----
+0.0.4
+-----
+
+- Separated implementation for ``Frame2D``
+- Improved performance for GLCM statistics
+- Use Gaussian + FFTConvolution for Non-GLCM Channel fitting
+- Implement GLCM statistics with FFTConvolution
+
+-----
 0.0.3
 -----
 - Implement Index Grabbing with ``get_xx`` ops.

--- a/src/frmodel/base/D2/frame/_frame_channel.py
+++ b/src/frmodel/base/D2/frame/_frame_channel.py
@@ -117,7 +117,7 @@ class _Frame2DChannel(ABC):
                  mex_g=False, ex_gr=False, ndi=False, veg=False,
                  veg_a=0.667, glcm_con=False, glcm_cor=False, glcm_ent=False,
                  glcm_by_x=1, glcm_by_y=1,
-                 glcm_radius=5, glcm_verbose=False) -> _Frame2DChannel:
+                 glcm_radius=5, glcm_verbose=False, conv_gauss_stdev=4) -> _Frame2DChannel:
         """ Gets selected channels
 
         Order is given by the argument order.
@@ -140,15 +140,18 @@ class _Frame2DChannel(ABC):
         :param glcm_by_y: GLCM By Y Parameter
         :param glcm_radius: GLCM Radius
         :param glcm_verbose: Whether to have glcm entropy generation give feedback
+        :param conv_gauss_stdev: The stdev of the gaussian kernel used to convolute existing channels if GLCM is used
         """
         return self.get_all_chns(self_, xy, hsv, ex_g, mex_g, ex_gr, ndi,
                                  veg, veg_a, glcm_con, glcm_cor, glcm_ent,
-                                 glcm_by_x, glcm_by_y, glcm_radius, glcm_verbose)
+                                 glcm_by_x, glcm_by_y, glcm_radius, glcm_verbose,
+                                 conv_gauss_stdev)
 
     def get_all_chns(self, self_=True, xy=True, hsv=True, ex_g=True, mex_g=True,
                      ex_gr=True, ndi=True, veg=True, veg_a=0.667,
                      glcm_con=True, glcm_cor=True, glcm_ent=True,
-                     glcm_by_x=1, glcm_by_y=1, glcm_radius=5, glcm_verbose=False) -> _Frame2DChannel:
+                     glcm_by_x=1, glcm_by_y=1, glcm_radius=5, glcm_verbose=False,
+                     conv_gauss_stdev=4) -> _Frame2DChannel:
         """ Gets all implemented channels, excluding possible.
 
         Order is given by the argument order.
@@ -171,6 +174,7 @@ class _Frame2DChannel(ABC):
         :param glcm_by_y: GLCM By Y Parameter
         :param glcm_radius: GLCM Radius
         :param glcm_verbose: Whether to have glcm entropy generation give feedback
+        :param conv_gauss_stdev: The stdev of the gaussian kernel used to convolute existing channels if GLCM is used
         """
 
         features = \
@@ -190,8 +194,8 @@ class _Frame2DChannel(ABC):
             # We also average the shifted frame with the current
 
             kernel_diam = glcm_radius * 2 + 1
-            kernel = np.outer(gaussian(kernel_diam + glcm_by_y, 8),
-                              gaussian(kernel_diam + glcm_by_x, 8))
+            kernel = np.outer(gaussian(kernel_diam + glcm_by_y, conv_gauss_stdev),
+                              gaussian(kernel_diam + glcm_by_x, conv_gauss_stdev))
             kernel = np.expand_dims(kernel, axis=-1)
             fft = fftconvolve(frame.data, kernel, mode='valid', axes=[0,1])
             glcm = self.get_glcm(

--- a/src/frmodel/base/D2/frame/_frame_channel.py
+++ b/src/frmodel/base/D2/frame/_frame_channel.py
@@ -359,9 +359,8 @@ class _Frame2DChannel(ABC):
                 Then we sum it up with np.sum, note that python sum is much slower on numpy arrays!
                 """
 
-                entropy = np.asarray([np.sum(i * np.log2(i))  # Shannon's Entropy
-                                      for g in c.swapaxes(0, 1)
-                                      for i in np.unique(g, return_counts=True)[1::2]])
+                entropy = np.asarray([np.sum(np.bincount(g) ** 2)
+                                      for g in c.swapaxes(0, 1)])
 
                 out[row, col, :] = entropy
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="frmodel",
-    version="0.0.3",
+    version="0.0.4",
     author="Eve-ning",
     author_email="dev_evening@hotmail.com",
     description="The base package to support frmodel data processing",


### PR DESCRIPTION
# GLCM Optimization

By using convolution instead of *frame_splitting* we can speed up the GLCM for **contrast** and **correlation** by a lot.

However, **entropy** is not affected.

