### PR TITLE
Channel/GLCM Flexibility

### DIFF
--- a/src/frmodel/base/D2/frame/_frame_channel.py
+++ b/src/frmodel/base/D2/frame/_frame_channel.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING, Tuple, Iterable
 
 import numpy as np
-from scipy.signal import fftconvolve
-from scipy.signal.windows import gaussian
 from skimage.color import rgb2hsv
 
 from frmodel.base.D2.frame._frame_channel_glcm import _Frame2DChannelGLCM
@@ -16,6 +14,7 @@ if TYPE_CHECKING:
 
 MAX_RGB = 255
 CHN = CONSTS.CHN
+
 
 class _Frame2DChannel(_Frame2DChannelGLCM):
 
@@ -33,40 +32,135 @@ class _Frame2DChannel(_Frame2DChannelGLCM):
     @abstractmethod
     def height(self): ...
 
-    def get_hsv(self) -> Tuple[np.ndarray, Tuple[str]]:
-        """ Creates a HSV """
-        return rgb2hsv(self.data_rgb().data), CONSTS.CHN.HSV
+    def get_all_chns(self,
+                 self_=False,
+                 exc_chns: Iterable[CHN] = None,
+                 glcm: _Frame2DChannel.GLCM = None) -> _Frame2DChannel:
+        """ Gets selected channels
 
-    def get_ex_g(self, modified=False) -> Tuple[np.ndarray, str]:
+        Order is given by the argument order.
+        R, G, B, X, Y, H, S, V, EX_G, MEX_G, EX_GR, NDI, VEG,
+        ConR, ConG, ConB, CorrR, CorrG, CorrB, EntR, EntG, EntB
+
+        :param self_: Include current frame
+        :param exc_chns: Excluded Channels
+        :param glcm: GLCM Object
+        """
+
+        self: 'Frame2D'
+        chns = [self.CHN.XY,
+                self.CHN.EX_G,
+                self.CHN.MEX_G,
+                self.CHN.HSV,
+                self.CHN.NDI,
+                self.CHN.VEG,
+                self.CHN.EX_GR]
+
+        return self.get_all_chns(self_, [c for c in chns if c not in exc_chns], glcm)
+
+    def get_chns(self,
+                 self_=True,
+                 chns: Iterable[CHN] = None,
+                 glcm: _Frame2DChannel.GLCM = None) -> _Frame2DChannel:
+        """ Gets all implemented channels, excluding possible.
+
+        Order is given by the argument order.
+        R, G, B, H, S, V, EX_G, MEX_G, EX_GR, NDI, VEG, X, Y,
+        ConR, ConG, ConB, CorrR, CorrG, CorrB, EntR, EntG, EntB
+
+        :param self_: Include current frame
+        :param chns: Channels
+        :param glcm: GLCM Object
+        """
+
+        labels = []
+        chns = [] if not chns else chns
+
+        self: 'Frame2D'
+        data = np.zeros([*self.shape[0:2],
+                          self._get_chn_size(chns) + self.shape[-1] if self_ else
+                          self._get_chn_size(chns)])
+
+        _chn_mapping: dict = {
+            CHN.XY:    self.get_xy,
+            CHN.HSV:   self.get_hsv,
+            CHN.EX_G:  self.get_ex_g,
+            CHN.EX_GR: self.get_ex_gr,
+            CHN.MEX_G: self.get_mex_g,
+            CHN.NDI:   self.get_ndi,
+            CHN.VEG:   self.get_ex_g
+        }
+
+        it = 0
+
+        if self_:
+            data[..., it:self.shape[-1]] = self.data
+            labels = [self.labels.keys()]
+            it += self.shape[-1]
+
+        for chn in chns:
+            length = len(chn) if isinstance(chn, Tuple) else 1
+            try:
+                data[..., it:it+length] = _chn_mapping[chn]()
+                labels.append(chn)
+            except KeyError:
+                if chn in (CHN.X, CHN.Y):
+                    KeyError(f"You cannot get {chn} separately from XY, call with CHN.HSV")
+                elif chn in (CHN.HUE, CHN.SATURATION, CHN.VALUE):
+                    KeyError(f"You cannot get {chn} separately from HSV, call with CHN.HSV")
+                elif chn in (CHN.RED, CHN.GREEN, CHN.BLUE, CHN.RGB):
+                    KeyError(f"You cannot get {chn}, these are bases value and cannot be directly calculated")
+                else:
+                    KeyError(f"Failed to find channel {chn}, I recommend to use CONSTS.CHN to get the correct"
+                             f"strings to call")
+            it += length
+
+        frame: 'Frame2D' = self.create(data=data, labels=labels)
+
+        if glcm:
+            if frame.shape[-1] == 0:
+                # Cannot convolute a 0 set. We'll still entertain get_glcm only.
+                frame = self.create(*self.get_glcm(glcm))
+            else:
+                frame = frame.convolute(radius=glcm.radius).append(*self.get_glcm(glcm))
+
+        return frame
+
+    def get_hsv(self: 'Frame2D') -> np.ndarray:
+        """ Creates a HSV """
+        return rgb2hsv(self.data_rgb().data)
+
+    def get_ex_g(self: 'Frame2D') -> np.ndarray:
         """ Calculates the excessive green index
 
         Original: 2g - 1r - 1b
-        Modified: 1.262g - 0.884r - 0.331b
-
-        :param modified: Whether to use the modified or not. Refer to docstring
         """
 
-        if modified:
-            return 1.262 * self.data_chn(CHN.RED).data -   \
-                   0.884 * self.data_chn(CHN.GREEN).data - \
-                   0.331 * self.data_chn(CHN.BLUE).data, CHN.MEX_G
+        return 2 * self.data_chn(CHN.RED).data - \
+               self.data_chn(CHN.GREEN).data - \
+               self.data_chn(CHN.BLUE).data
 
-        else:
-            return 2 * self.data_chn(CHN.RED).data -   \
-                       self.data_chn(CHN.GREEN).data - \
-                       self.data_chn(CHN.BLUE).data, CHN.EX_G
+    def get_mex_g(self: 'Frame2D') -> np.ndarray:
+        """ Calculates the Modified excessive green index
 
-    def get_ex_gr(self) -> Tuple[np.ndarray, str]:
+        Modified: 1.262g - 0.884r - 0.331b
+        """
+
+        return 1.262 * self.data_chn(CHN.RED).data - \
+               0.884 * self.data_chn(CHN.GREEN).data - \
+               0.331 * self.data_chn(CHN.BLUE).data
+
+    def get_ex_gr(self: 'Frame2D') -> np.ndarray:
         """ Calculates the excessive green minus excess red index
 
         2g - r - b - 1.4r + g = 3g - 2.4r - b
         """
 
-        return 3   * self.data_chn(CHN.RED).data -   \
+        return 3 * self.data_chn(CHN.RED).data - \
                2.4 * self.data_chn(CHN.GREEN).data - \
-                     self.data_chn(CHN.BLUE).data, CHN.EX_GR
+               self.data_chn(CHN.BLUE).data
 
-    def get_ndi(self) -> Tuple[np.ndarray, str]:
+    def get_ndi(self: 'Frame2D') -> np.ndarray:
         """ Calculates the Normalized Difference Index
 
         (g - r) / (g + r)
@@ -80,9 +174,9 @@ class _Frame2DChannel(_Frame2DChannelGLCM):
                                self.data_chn(CHN.RED)  .data.astype(np.int)),
                 copy=False, nan=0, neginf=0, posinf=0)
 
-        return x, CONSTS.CHN.NDI
+        return x
 
-    def get_veg(self, const_a: float = 0.667) -> Tuple[np.ndarray, str]:
+    def get_veg(self: 'Frame2D', const_a: float = 0.667) -> np.ndarray:
         """ Calculates the Vegetative Index
 
         g / {(r^a) * [b^(1 - a)]}
@@ -95,9 +189,9 @@ class _Frame2DChannel(_Frame2DChannelGLCM):
                               (np.power(self.data_chn(CHN.RED).data.astype(np.float), const_a) *
                                np.power(self.data_chn(CHN.BLUE).data.astype(np.float), 1 - const_a)),
                               copy=False, nan=0, neginf=0, posinf=0)
-        return x, CONSTS.CHN.VEG
+        return x
 
-    def get_xy(self) -> Tuple[np.ndarray, Tuple[str]]:
+    def get_xy(self: 'Frame2D') -> np.ndarray:
         """ Creates the XY Coord Array """
 
         # We create a new array to copy self over we expand the last axis by 2
@@ -107,125 +201,4 @@ class _Frame2DChannel(_Frame2DChannelGLCM):
         buffer[..., 0] = np.tile(np.arange(0, self.width()), (self.height(), 1))
         buffer[..., 1] = np.tile(np.arange(0, self.height()), (self.width(), 1)).swapaxes(0, 1)
 
-        return buffer, CONSTS.CHN.XY
-
-    def get_chns(self, self_=False, xy=False, hsv=False, ex_g=False,
-                 mex_g=False, ex_gr=False, ndi=False, veg=False,
-                 veg_a=0.667, glcm_con=False, glcm_cor=False, glcm_ent=False,
-                 glcm_by_x=1, glcm_by_y=1,
-                 glcm_radius=5, glcm_verbose=False,
-                 conv_gauss_stdev=4) -> _Frame2DChannel:
-        """ Gets selected channels
-
-        Order is given by the argument order.
-        R, G, B, X, Y, H, S, V, EX_G, MEX_G, EX_GR, NDI, VEG,
-        ConR, ConG, ConB, CorrR, CorrG, CorrB, EntR, EntG, EntB
-
-        :param self_: Include current frame
-        :param xy: XY Coordinates
-        :param hsv: Hue, Saturation, Value
-        :param ex_g: Excess Green
-        :param mex_g: Modified Excess Green
-        :param ex_gr: Excess Green Minus Red
-        :param ndi: Normalized Difference Index
-        :param veg: Vegetative Index
-        :param veg_a: Vegatative Index Const A
-        :param glcm_con: GLCM Contrast
-        :param glcm_cor: GLCM Correlation
-        :param glcm_ent: GLCM Entropy
-        :param glcm_by_x: GLCM By X Parameter
-        :param glcm_by_y: GLCM By Y Parameter
-        :param glcm_radius: GLCM Radius
-        :param glcm_verbose: Whether to have glcm entropy generation give feedback
-        :param conv_gauss_stdev: The stdev of the gaussian kernel used to convolute existing channels if GLCM is used
-        """
-        return self.get_all_chns(self_, xy, hsv, ex_g, mex_g, ex_gr, ndi,
-                                 veg, veg_a, glcm_con, glcm_cor, glcm_ent,
-                                 glcm_by_x, glcm_by_y, glcm_radius, glcm_verbose,
-                                 conv_gauss_stdev)
-
-    def get_all_chns(self, self_=True, xy=True, hsv=True, ex_g=True, mex_g=True,
-                     ex_gr=True, ndi=True, veg=True, veg_a=0.667,
-                     glcm_con=True, glcm_cor=True, glcm_ent=True,
-                     glcm_by_x=1, glcm_by_y=1, glcm_radius=5, glcm_verbose=False,
-                     conv_gauss_stdev=4, conv_method='nearest') -> _Frame2DChannel:
-        """ Gets all implemented channels, excluding possible.
-
-        Order is given by the argument order.
-        R, G, B, H, S, V, EX_G, MEX_G, EX_GR, NDI, VEG, X, Y,
-        ConR, ConG, ConB, CorrR, CorrG, CorrB, EntR, EntG, EntB
-
-        :param self_: Include current frame
-        :param xy: XY Coordinates
-        :param hsv: Hue, Saturation, Value
-        :param ex_g: Excess Green
-        :param mex_g: Modified Excess Green
-        :param ex_gr: Excess Green Minus Red
-        :param ndi: Normalized Difference Index
-        :param veg: Vegetative Index
-        :param veg_a: Vegatative Index Const A
-        :param glcm_con: GLCM Contrast
-        :param glcm_cor: GLCM Correlation
-        :param glcm_ent: GLCM Entropy
-        :param glcm_by_x: GLCM By X Parameter
-        :param glcm_by_y: GLCM By Y Parameter
-        :param glcm_radius: GLCM Radius
-        :param glcm_verbose: Whether to have glcm entropy generation give feedback
-        :param conv_gauss_stdev: The stdev of the gaussian kernel used to convolute existing channels if GLCM is used
-        :param conv_method: Can be 'average' or 'nearest'
-        """
-
-        features = []
-        labels = []
-
-        def add_feature(feature: np.ndarray, label: str or Tuple[str]):
-            # Convenience function to help add features
-
-            # If the feature is a singular channel, we need to promote it into a 3dim
-            features.append(feature if feature.ndim == 3 else feature[..., np.newaxis])
-            if isinstance(label, str):
-                # noinspection PyTypeChecker
-                labels.append(label)
-            else:
-                labels.extend(label)
-
-        self:'Frame2D'
-        if self_ :add_feature(self.data, self.labels.keys())
-        if xy    :add_feature(*self.get_xy()               )
-        if hsv   :add_feature(*self.get_hsv()              )
-        if ex_g  :add_feature(*self.get_ex_g()             )
-        if mex_g :add_feature(*self.get_ex_g(True)         )
-        if ex_gr :add_feature(*self.get_ex_gr()            )
-        if ndi   :add_feature(*self.get_ndi()              )
-        if veg   :add_feature(*self.get_veg(veg_a)         )
-
-        if features:
-            frame = self.create(data=np.concatenate(features, axis=2),
-                                labels=labels)
-        else:
-            frame = None
-
-        if glcm_con or glcm_cor or glcm_ent:
-            glcm, glcm_labels = self.get_glcm(
-                contrast=glcm_con, correlation=glcm_cor, entropy=glcm_ent,
-                by_x=glcm_by_x, by_y=glcm_by_y, radius=glcm_radius, verbose=glcm_verbose
-                )
-
-            labels.extend(glcm_labels)
-
-            if frame:
-                # We trim the frame so that the new glcm can fit
-                # We also average the shifted frame with the current
-                kernel_diam = glcm_radius * 2 + 1
-                if conv_method == 'nearest':
-                    kernel = np.zeros([kernel_diam + 1, kernel_diam + 1, 1])
-                    kernel[kernel.shape[0] // 2, kernel.shape[1] // 2] = 1
-                else:  # 'average'
-                    kernel = np.outer(gaussian(kernel_diam + glcm_by_y, conv_gauss_stdev),
-                                      gaussian(kernel_diam + glcm_by_x, conv_gauss_stdev))
-                    kernel = np.expand_dims(kernel, axis=-1)
-                fft = fftconvolve(frame.data, kernel, mode='valid', axes=[0,1])
-                glcm = np.concatenate([fft, glcm], axis=2)
-            return self.create(data=glcm, labels=labels)
-
-        return frame
+        return buffer

--- a/src/frmodel/base/D2/frame/_frame_channel_glcm.py
+++ b/src/frmodel/base/D2/frame/_frame_channel_glcm.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Tuple, List
+from dataclasses import dataclass, field
+from typing import Tuple, List, TYPE_CHECKING
 
 import numpy as np
 from scipy.signal import fftconvolve
@@ -12,23 +13,29 @@ from frmodel.base import CONSTS
 from frmodel.base.D2.frame._cy_corr import cy_corr
 from frmodel.base.D2.frame._cy_entropy import cy_entropy
 
+if TYPE_CHECKING:
+    from frmodel.base.D2.frame2D import Frame2D
+
 MAX_RGB = 255
 
 class _Frame2DChannelGLCM(ABC):
 
     data: np.ndarray
+
+    @dataclass
+    class GLCM:
+        by_x: int = 1
+        by_y: int = 1
+        radius: int = 5
+        contrast:    List[CONSTS.CHN] = field(default_factory=[])
+        correlation: List[CONSTS.CHN] = field(default_factory=[])
+        entropy:     List[CONSTS.CHN] = field(default_factory=[])
+        verbose: bool = True
     
     @abstractmethod
     def data_rgb(self): ...
 
-    def get_glcm(self,
-                 by_x: int = 1,
-                 by_y: int = 1,
-                 radius: int = 5,
-                 contrast: bool = True,
-                 correlation: bool = True,
-                 entropy: bool = True,
-                 verbose: bool = False) -> Tuple[np.ndarray, List[str]]:
+    def get_glcm(self, glcm:GLCM) -> Tuple[np.ndarray, List[str]]:
         """ This will get the GLCM statistics for this window
 
         In order:
@@ -73,68 +80,80 @@ class _Frame2DChannelGLCM(ABC):
             frame.size - by - radius * 2
         """
 
-        rgb = self.data_rgb().data.astype(np.int32)
-        rgb_a = rgb[:-by_y, :-by_x]
-        rgb_b = rgb[by_y:, by_x:]
+        self: 'Frame2D'
 
-        features = []
+        con_len = self._get_chn_size(glcm.contrast)
+        cor_len = self._get_chn_size(glcm.correlation)
+        ent_len = self._get_chn_size(glcm.entropy)
+
+        data = np.zeros(shape=[*self.crop_glcm(glcm.radius).shape[0:2], con_len + cor_len + ent_len])
+
+        def pair_ar(ar: np.ndarray):
+            return ar[:-glcm.by_y, :-glcm.by_x], ar[glcm.by_y:, glcm.by_x:]
+
         labels = []
 
-        def add_feature(feature: np.ndarray, label: str or Tuple[str]):
-            # Convenience function to help add features
+        i = 0
 
-            # If the feature is a singular channel, we need to promote it into a 3dim
-            features.append(feature if feature.ndim == 3 else feature[..., np.newaxis])
-            if isinstance(label, str):
-                # noinspection PyTypeChecker
-                labels.append(label)
-            else:
-                labels.extend(label)
+        if glcm.contrast:
+            data[..., i:i + con_len] =\
+                self._get_glcm_contrast_py(*pair_ar(self.data_chn(glcm.contrast).data),
+                                           radius=glcm.radius)
+            i += con_len
+            labels.extend(CONSTS.CHN.GLCM.CON(list(self._util_flatten(glcm.contrast))))
 
-        if contrast:    add_feature(*self._get_glcm_contrast_py(rgb_a, rgb_b, radius))
-        if correlation: add_feature(*self._get_glcm_correlation_cy(rgb_a, rgb_b, radius, verbose))
-        if entropy:     add_feature(*self._get_glcm_entropy_cy(rgb_a, rgb_b, radius, verbose))
+        if glcm.correlation:
+            data[..., i:i + cor_len] =\
+                self._get_glcm_correlation_cy(*pair_ar(self.data_chn(glcm.contrast).data),
+                                              radius=glcm.radius, verbose=glcm.verbose)
+            i += cor_len
+            labels.extend(CONSTS.CHN.GLCM.COR(list(self._util_flatten(glcm.correlation))))
 
-        return np.concatenate(features, axis=2), labels
+        if glcm.correlation:
+            data[..., i:i + ent_len] =\
+                self._get_glcm_entropy_cy(*pair_ar(self.data_chn(glcm.contrast).data),
+                                          radius=glcm.radius, verbose=glcm.verbose)
+            labels.extend(CONSTS.CHN.GLCM.ENT(list(self._util_flatten(glcm.entropy))))
+
+        return data, labels
 
     @staticmethod
-    def _get_glcm_contrast_py(rgb_a: np.ndarray,
-                              rgb_b: np.ndarray,
-                              radius) -> Tuple[np.ndarray, Tuple[str]]:
+    def _get_glcm_contrast_py(ar_a: np.ndarray,
+                              ar_b: np.ndarray,
+                              radius) -> np.ndarray:
         """ Pure python implementation of Contrast.
 
         Cython isn't needed as it's purely vectorizable.
 
         Create the difference matrix, then convolve with a 1 filled kernel
 
-        :param rgb_a: Offset ar A
-        :param rgb_b: Offset ar B
+        :param ar_a: Offset ar A
+        :param ar_b: Offset ar B
         :param radius: Radius of window
         """
 
-        ar = (rgb_a - rgb_b) ** 2
-        return fftconvolve(ar, np.ones(shape=[radius * 2 + 1, radius * 2 + 1, 1]), mode='valid'),\
-               CONSTS.CHN.GLCM.CON_RGB
+        ar = (ar_a - ar_b) ** 2
+        return fftconvolve(ar, np.ones(shape=[radius * 2 + 1, radius * 2 + 1, 1]), mode='valid')
 
     @staticmethod
-    def _get_glcm_correlation_py(rgb_a: np.ndarray,
-                              rgb_b: np.ndarray,
-                              radius) -> Tuple[np.ndarray, Tuple[str]]:
+    def _get_glcm_correlation_py(ar_a: np.ndarray,
+                              ar_b: np.ndarray,
+                              radius) -> np.ndarray:
         """ Uses Pure Python to implement correlation GLCM
 
-        :param rgb_a: Offset ar A
-        :param rgb_b: Offset ar B
+        :param ar_a: Offset ar A
+        :param ar_b: Offset ar B
         :param radius: Radius of window
         """
 
         diam = radius * 2 + 1
 
-        windows_a = view_as_windows(rgb_a, [diam, diam, 3], step=1).squeeze()
+        windows_a = view_as_windows(ar_a, [diam, diam, 3], step=1).squeeze()
         windows_a_mean = np.mean(windows_a, axis=(2, 3))
         windows_a_delta = windows_a - np.tile(np.expand_dims(windows_a_mean, (2, 3)), (1, 1, diam, diam, 1))
         windows_a_std = np.std(windows_a, axis=(2, 3))
 
-        windows_b = view_as_windows(rgb_b, [diam, diam, 3], step=1).squeeze()
+        windows_b = view_as_windows(ar_b, [diam, diam, 3], step=1).squeeze()
         windows_b_mean = np.mean(windows_b, axis=(2, 3))
         windows_b_delta = windows_b - np.tile(np.expand_dims(windows_b_mean, (2, 3)), (1, 1, diam, diam, 1))
         windows_b_std = np.std(windows_b, axis=(2, 3))
@@ -144,12 +163,12 @@ class _Frame2DChannelGLCM(ABC):
             windows_a_std * windows_b_std,
             where=windows_a_std * windows_b_std != 0,
             out=np.zeros_like(windows_a_std)
-        ), CONSTS.CHN.GLCM.COR_RGB
+        )
 
     @staticmethod
-    def _get_glcm_correlation_naive_py(rgb_a: np.ndarray,
-                                       rgb_b: np.ndarray,
-                                       radius) -> Tuple[np.ndarray, Tuple[str]]:
+    def _get_glcm_correlation_naive_py(ar_a: np.ndarray,
+                                       ar_b: np.ndarray,
+                                       radius) -> np.ndarray:
         """ Legacy Naive Correlation Calculation in Pure Python
 
         This is naive because the formula doesn't seem to match up with the basis definition of Correlation.
@@ -161,24 +180,24 @@ class _Frame2DChannelGLCM(ABC):
 
         Corr = (a * b - (E(a) - E(b))) / std(a) * std(b)
 
-        :param rgb_a: Offset ar A
-        :param rgb_b: Offset ar B
+        :param ar_a: Offset ar A
+        :param ar_b: Offset ar B
         :param radius: Radius of window
         """
 
         kernel = np.ones(shape=[radius * 2 + 1, radius * 2 + 1, 1])
 
-        conv_ab = fftconvolve(rgb_a * rgb_b, kernel, mode='valid')
+        conv_ab = fftconvolve(ar_a * ar_b, kernel, mode='valid')
 
-        conv_a = fftconvolve(rgb_a, kernel, mode='valid')
-        conv_b = fftconvolve(rgb_b, kernel, mode='valid')
+        conv_a = fftconvolve(ar_a, kernel, mode='valid')
+        conv_b = fftconvolve(ar_b, kernel, mode='valid')
 
         # E(A) & E(B)
         conv_ae = conv_a / kernel.size
         conv_be = conv_b / kernel.size
 
-        conv_a2 = fftconvolve(rgb_a ** 2, kernel, mode='valid')
-        conv_b2 = fftconvolve(rgb_b ** 2, kernel, mode='valid')
+        conv_a2 = fftconvolve(ar_a ** 2, kernel, mode='valid')
+        conv_b2 = fftconvolve(ar_b ** 2, kernel, mode='valid')
 
         # E(A^2) & E(B^2)
         conv_ae2 = conv_a2 / kernel.size
@@ -197,52 +216,52 @@ class _Frame2DChannelGLCM(ABC):
         with np.errstate(divide='ignore', invalid='ignore'):
             cor = (conv_ab - (conv_ae - conv_be) * (2 * radius + 1) ** 2) /\
                    np.sqrt(conv_stda ** 2 * conv_stdb ** 2)
-            return np.nan_to_num(cor, copy=False, nan=0, neginf=-1, posinf=1), CONSTS.CHN.GLCM.COR_RGB
+            return np.nan_to_num(cor, copy=False, nan=0, neginf=-1, posinf=1)
 
     @staticmethod
-    def _get_glcm_correlation_cy(rgb_a: np.ndarray,
-                                 rgb_b: np.ndarray,
+    def _get_glcm_correlation_cy(ar_a: np.ndarray,
+                                 ar_b: np.ndarray,
                                  radius: int,
                                  verbose: bool) -> Tuple[np.ndarray, Tuple[str]]:
         """ Correlation In Cython
 
         Uses the basis GLCM definition.
 
-        :param rgb_a: Offset ar A
-        :param rgb_b: Offset ar B
+        :param ar_a: Offset ar A
+        :param ar_b: Offset ar B
         :param radius: Radius of window
         """
 
-        return cy_corr(rgb_a.astype(np.uint8),
-                       rgb_b.astype(np.uint8),
-                       radius, verbose) / ((2 * radius + 1) ** 2), CONSTS.CHN.GLCM.COR_RGB
+        return cy_corr(ar_a.astype(np.uint8),
+                       ar_b.astype(np.uint8),
+                       radius, verbose) / ((2 * radius + 1) ** 2)
 
     @staticmethod
-    def _get_glcm_entropy_cy(rgb_a: np.ndarray,
-                             rgb_b: np.ndarray,
+    def _get_glcm_entropy_cy(ar_a: np.ndarray,
+                             ar_b: np.ndarray,
                              radius,
                              verbose
-                             ) -> Tuple[np.ndarray, Tuple[str]]:
+                             ) -> np.ndarray:
         """ Gets the entropy, uses the Cython entropy algorithm
 
-        :param rgb_a: Offset ar A
-        :param rgb_b: Offset ar B
+        :param ar_a: Offset ar A
+        :param ar_b: Offset ar B
         :param radius: Radius of window
         """
-        rgb_c = rgb_a + rgb_b * (MAX_RGB + 1)
+        rgb_c = ar_a + ar_b * (MAX_RGB + 1)
 
-        return cy_entropy(rgb_c.astype(np.uint16), radius, verbose), CONSTS.CHN.GLCM.ENT_RGB
+        return cy_entropy(rgb_c.astype(np.uint16), radius, verbose)
 
     @staticmethod
-    def _get_glcm_entropy_py(rgb_a: np.ndarray,
-                             rgb_b: np.ndarray,
+    def _get_glcm_entropy_py(ar_a: np.ndarray,
+                             ar_b: np.ndarray,
                              radius,
                              verbose
-                             ) -> Tuple[np.ndarray, Tuple[str]]:
+                             ) -> np.ndarray:
         """ Gets the entropy in Pure Python
 
-        :param rgb_a: Offset ar A
-        :param rgb_b: Offset ar B
+        :param ar_a: Offset ar A
+        :param ar_b: Offset ar B
         :param radius: Radius of window
         :param verbose: Whether to show progress of entropy
         """
@@ -252,14 +271,14 @@ class _Frame2DChannelGLCM(ABC):
         # However, the main reason is that so that we can use np.unique without constructing
         # a tuple hash for each pair!
 
-        rgb_a = rgb_a.astype(np.uint8)
-        rgb_b = rgb_b.astype(np.uint8)
+        ar_a = ar_a.astype(np.uint8)
+        ar_b = ar_b.astype(np.uint8)
 
-        cells = view_as_windows(rgb_a * (MAX_RGB + 1) + rgb_b,
+        cells = view_as_windows(ar_a * (MAX_RGB + 1) + ar_b,
                                 [radius * 2 + 1, radius * 2 + 1, 3], step=1).squeeze()
 
-        out = np.zeros((rgb_a.shape[0] - radius * 2,
-                        rgb_a.shape[1] - radius * 2,
+        out = np.zeros((ar_a.shape[0] - radius * 2,
+                        ar_a.shape[1] - radius * 2,
                         3))  # RGB count
 
         for row, _ in enumerate(tqdm(cells, total=len(cells), disable=not verbose)):
@@ -282,4 +301,4 @@ class _Frame2DChannelGLCM(ABC):
                 entropy = np.asarray([np.sum(np.bincount(g) ** 2) for g in c.swapaxes(0, 1)])
                 out[row, col, :] = entropy
 
-        return out, CONSTS.CHN.GLCM.ENT_RGB
+        return out

--- a/src/frmodel/base/D2/frame/_frame_channel_glcm.py
+++ b/src/frmodel/base/D2/frame/_frame_channel_glcm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Tuple, List, TYPE_CHECKING
+from warnings import warn
 
 import numpy as np
 from scipy.signal import fftconvolve
@@ -109,7 +110,11 @@ class _Frame2DChannelGLCM(ABC):
             i += cor_len
             labels.extend(CONSTS.CHN.GLCM.COR(list(self._util_flatten(glcm.correlation))))
 
-        if glcm.correlation:
+        if glcm.entropy:
+            if any([c not in CONSTS.CHN.RGB for c in glcm.entropy]):
+                raise Exception("Note that for non-RGB Entropies, it will be wildly incorrect as it assumes a "
+                                "(0-255) value boundary")
+
             data[..., i:i + ent_len] =\
                 self._get_glcm_entropy_cy(*pair_ar(self.data_chn(glcm.contrast).data),
                                           radius=glcm.radius, verbose=glcm.verbose)

--- a/src/frmodel/base/D2/frame/_frame_image.py
+++ b/src/frmodel/base/D2/frame/_frame_image.py
@@ -37,7 +37,7 @@ class _Frame2DImage(ABC):
         self: 'Frame2D'
         Image.fromarray(self.data_rgb().data.astype(np.uint8)).save(file_path, **kwargs)
 
-    def convolute(self, radius: int, method: str = 'nearest') -> Frame2D:
+    def convolute(self: 'Frame2D', radius: int, method: str = 'nearest') -> Frame2D:
         """ Convolutes the Frame. """
 
         # We trim the frame so that the new glcm can fit
@@ -52,7 +52,6 @@ class _Frame2DImage(ABC):
                               gaussian(kernel_diam + 1, radius))
             kernel = np.expand_dims(kernel, axis=-1)
 
-        self: 'Frame2D'
         return self.create(fftconvolve(self.data, kernel, mode='valid', axes=[0, 1]), self.labels)
 
     def _rescale(self,

--- a/src/frmodel/base/D2/frame/_frame_plot.py
+++ b/src/frmodel/base/D2/frame/_frame_plot.py
@@ -30,7 +30,7 @@ class Frame2DPlot:
         """
         channels = self.f.data.shape[-1]
         if self.subplot_shape is None:
-            rows = int(channels ** 0.5)
+            rows = ceil(channels ** 0.5)
             cols = ceil(channels / rows)
         else:
             rows = self.subplot_shape[0]
@@ -111,7 +111,8 @@ class Frame2DPlot:
         :param colorscale: The color scale to use when plotting.
         :returns: A plt.Figure
         """
-        d = self.f.get_chns(self_=True,xy=True).data_flatten_xy()
+        d = self.f.get_chns(self_=True,
+                            chns=[self.f.CHN.XY]).data_flatten_xy()
         if sample_size:
             d = d[np.random.choice(d.shape[0], replace=False, size=sample_size)]
 

--- a/src/frmodel/base/D2/frame/_frame_scoring.py
+++ b/src/frmodel/base/D2/frame/_frame_scoring.py
@@ -8,8 +8,6 @@ import numpy as np
 from sklearn.metrics import homogeneity_completeness_v_measure
 from sklearn.preprocessing import LabelEncoder
 
-from frmodel.base import CONSTS
-
 if TYPE_CHECKING:
     from frmodel.base.D2.frame2D import Frame2D
 

--- a/src/frmodel/base/D2/frame2D.py
+++ b/src/frmodel/base/D2/frame2D.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from copy import deepcopy
-from typing import List, Tuple, Iterable
+from typing import List, Tuple, Iterable, Union, Any
 
 import numpy as np
 from sklearn.neighbors import KDTree
@@ -41,7 +40,7 @@ class Frame2D(_Frame2DLoader,
 
     def __init__(self, data: np.ndarray, labels: str or dict or List[str]):
         self._data = data
-        labels = [labels] if isinstance(labels, str) else labels
+        labels = [labels] if isinstance(labels, str) else list(self._util_flatten(labels))
 
         if data.ndim == 2: data = data[..., np.newaxis]
         assert data.ndim == 3 , f"Number of dimensions for initialization must be 2 or 3. (Given: {data.ndim})"
@@ -53,6 +52,9 @@ class Frame2D(_Frame2DLoader,
             labels = {k: e for e, k in enumerate(labels)}
 
         self._labels = labels
+
+    class CHN(CONSTS.CHN):
+        pass
 
     @staticmethod
     def create(data:np.ndarray, labels: dict or List[str]) -> Frame2D:
@@ -103,23 +105,14 @@ class Frame2D(_Frame2DLoader,
         """ Converts keys to indexes for splicing """
 
         if isinstance(labels, str): labels = [labels]
-        else: labels = self._flatten(labels)
+        else: labels = list(self._util_flatten(labels))
 
         try:
             return [self._labels[label] for label in labels]
         except KeyError:
             raise KeyError(f"Labels {[label for label in labels if label not in self._labels]} not found in the Frame.")
 
-    @staticmethod
-    def _flatten(l):
-        """ https://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists """
-        for el in l:
-            if isinstance(el, Iterable) and not isinstance(el, (str, bytes)):
-                yield from Frame2D._flatten(el)
-            else:
-                yield el
-
-    def data_chn(self, labels: str or List[str]) -> Frame2D:
+    def data_chn(self, labels: Union[List, CONSTS.CHN, Any]) -> Frame2D:
         """ Gets channels as another Frame2D
 
         :param labels: Can be a single str or multiple in a List"""
@@ -177,3 +170,18 @@ class Frame2D(_Frame2DLoader,
 
     def width(self) -> int:
         return self.shape[1]
+
+    @staticmethod
+    def _get_chn_size(chns: Iterable[CONSTS.CHN]) -> int:
+        """ This gets the channel size """
+        return len(list(Frame2D._util_flatten(chns)))
+
+    @staticmethod
+    def _util_flatten(iterable):
+        """ Flattens potentially nested iterables """
+        """ https://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists """
+        for el in iterable:
+            if isinstance(el, Iterable) and not isinstance(el, (str, bytes)):
+                yield from Frame2D._util_flatten(el)
+            else:
+                yield el

--- a/src/frmodel/base/D2/frame2D.py
+++ b/src/frmodel/base/D2/frame2D.py
@@ -102,10 +102,22 @@ class Frame2D(_Frame2DLoader,
     def _labels_to_ix(self, labels: str or List[str]):
         """ Converts keys to indexes for splicing """
 
+        if isinstance(labels, str): labels = [labels]
+        else: labels = self._flatten(labels)
+
         try:
-            return self._labels[labels] if isinstance(labels, str) else [self._labels[label] for label in labels]
+            return [self._labels[label] for label in labels]
         except KeyError:
             raise KeyError(f"Labels {[label for label in labels if label not in self._labels]} not found in the Frame.")
+
+    @staticmethod
+    def _flatten(l):
+        """ https://stackoverflow.com/questions/2158395/flatten-an-irregular-list-of-lists """
+        for el in l:
+            if isinstance(el, Iterable) and not isinstance(el, (str, bytes)):
+                yield from Frame2D._flatten(el)
+            else:
+                yield el
 
     def data_chn(self, labels: str or List[str]) -> Frame2D:
         """ Gets channels as another Frame2D

--- a/src/frmodel/base/D2/kmeans2D.py
+++ b/src/frmodel/base/D2/kmeans2D.py
@@ -39,7 +39,8 @@ class KMeans2D:
         self.frame_1dmask = frame_1dmask
 
     def frame_masked(self, with_xy: bool = True):
-        return self.frame.get_chns(self_=True, xy=True).data_flatten_xy()[self.frame_1dmask, :]
+        return self.frame.get_chns(self_=True, chns=[Frame2D.CHN.XY])\
+                   .data_flatten_xy()[self.frame_1dmask, :]
 
     def as_frame(self) -> Frame2D:
         """ Converts current model into Frame2D based on labels. Places label at the end of channel dimension

--- a/src/frmodel/base/consts.py
+++ b/src/frmodel/base/consts.py
@@ -1,8 +1,12 @@
+from typing import Tuple, Iterable
+
+
 class CONSTS:
     """ This class holds all the constants.
 
     This is to facilitate magic constants/numbers around the program.
     """
+
     class CHN:
         X           = "X"
         Y           = "Y"
@@ -27,18 +31,16 @@ class CONSTS:
         LCI         = "LCI"
 
         class GLCM:
-            CON_RED   = "CON_R"
-            CON_GREEN = "CON_G"
-            CON_BLUE  = "CON_B"
-            CON_RGB   = (CON_RED, CON_GREEN, CON_BLUE)
-            COR_RED   = "COR_R"
-            COR_GREEN = "COR_G"
-            COR_BLUE  = "COR_B"
-            COR_RGB   = (COR_RED, COR_GREEN, COR_BLUE)
-            ENT_RED   = "ENT_R"
-            ENT_GREEN = "ENT_G"
-            ENT_BLUE  = "ENT_B"
-            ENT_RGB   = (ENT_RED, ENT_GREEN, ENT_BLUE)
+            @staticmethod
+            def _head(pref, suf):
+                return tuple(f"{pref}_{s}" for s in suf) if isinstance(suf, Iterable) else f"{pref}_{suf}"
+
+            @staticmethod
+            def CON(x): return CONSTS.CHN.GLCM._head("CON", x)
+            @staticmethod
+            def COR(x): return CONSTS.CHN.GLCM._head("COR", x)
+            @staticmethod
+            def ENT(x): return CONSTS.CHN.GLCM._head("ENT", x)
 
         class KMEANS:
             LABEL = "KM_LABEL"

--- a/src/frmodel/express/channel/channel.py
+++ b/src/frmodel/express/channel/channel.py
@@ -17,7 +17,8 @@ def channel_analysis(image_path: str,
     """
 
     f = Frame2D.from_image(image_path, scale=image_scale)
-    f = f.get_all_chns(xy=not exclude_xy, glcm_verbose=verbose)
+    f = f.get_all_chns(exc_chns=[Frame2D.CHN.XY] if exclude_xy else [],
+                       glcm=Frame2D.GLCM(verbose=verbose))
     fig = f.plot(f.labels).image(scale=plot_scale)
 
     return fig

--- a/src/frmodel/express/kmeans/_kmeans_scoring.py
+++ b/src/frmodel/express/kmeans/_kmeans_scoring.py
@@ -41,7 +41,7 @@ def kmeans_matrix(test_path: str,
     """
     f = Frame2D.from_image(test_path, scale=scale)
     score = Frame2D.from_image(score_path, scale=scale)
-    frame = f.get_all_chns(glcm_verbose=verbose, glcm_radius=glcm_radius)
+    frame = f.get_all_chns(glcm=Frame2D.GLCM(verbose=verbose, radius=radius))
 
     try: os.makedirs(output_dir + "/" + imgs_dir)
     except OSError: pass

--- a/src/frmodel/express/kmeans/kmeans_scoring.py
+++ b/src/frmodel/express/kmeans/kmeans_scoring.py
@@ -1,6 +1,6 @@
 from sklearn.cluster import KMeans
 from sklearn.metrics import homogeneity_completeness_v_measure
-from sklearn.preprocessing import scale, minmax_scale
+from sklearn.preprocessing import scale
 import pandas as pd
 import seaborn as sns
 import numpy as np
@@ -39,6 +39,7 @@ def kmeans_scoring_12122020(test_path: str,
     :param img_scale: The scaling of the test/score loaded in
     :param clusters_mnl: Clusters to use for Meaningless Clustering
     :param clusters_mnf: Clusters to use for Meaningful Clustering
+    :param scatter_size: Scatter size of plot
     :param verbose: Whether to output into console the details
     :return:
     """

--- a/tests/base/D2/test_glcm.py
+++ b/tests/base/D2/test_glcm.py
@@ -12,25 +12,22 @@ class GLCMTest(TestD2):
         ar = np.asarray([[5, 8, 9, 5],
                          [0, 0, 1, 7],
                          [6, 9, 2, 4],
-                         [5, 2, 4, 2]])
+                         [5, 2, 4, 2]]).transpose()[...,np.newaxis]
 
-        ar = np.tile(ar, [3, 1, 1]).swapaxes(0,1).swapaxes(1,2)
+        f = Frame2D(ar.astype(np.uint8), CONSTS.CHN.RED)
+        fc = f.get_chns(self_=False,
+                        glcm=Frame2D.GLCM(radius=1,
+                                     contrast=[CONSTS.CHN.RED],
+                                     correlation=[CONSTS.CHN.RED],
+                                     entropy=[CONSTS.CHN.RED])
+                        )
 
-        f = Frame2D(ar.astype(np.uint8), CONSTS.CHN.RGB)
-        fc = f.get_chns(glcm_con=True, glcm_cor=True, glcm_ent=True, glcm_radius=1)
-        ar2 = fc.data.squeeze()
+        """ The reason why I made calling this so verbose is to make it easy for development. """
 
-        self.assertAlmostEqual(ar2[0], ar2[1])
-        self.assertAlmostEqual(ar2[1], ar2[2])
-        self.assertAlmostEqual(ar2[2], 213)
-
-        self.assertAlmostEqual(ar2[3], ar2[4])
-        self.assertAlmostEqual(ar2[4], ar2[5])
-        self.assertAlmostEqual(ar2[5], -0.12209306360906494, places=4)
-
-        self.assertAlmostEqual(ar2[6], ar2[7])
-        self.assertAlmostEqual(ar2[7], ar2[8])
-        self.assertAlmostEqual(ar2[8], 1)
+        self.assertAlmostEqual(fc.data_chn(fc.CHN.GLCM.CON(fc.CHN.RED)).data.squeeze(), 213)
+        self.assertAlmostEqual(fc.data_chn(fc.CHN.GLCM.COR(fc.CHN.RED)).data.squeeze(), -0.12209306360906494,
+                               places=4)
+        self.assertAlmostEqual(fc.data_chn(fc.CHN.GLCM.ENT(fc.CHN.RED)).data.squeeze(), 1)
 
 
 if __name__ == '__main__':

--- a/tests/base/D2/test_plot.py
+++ b/tests/base/D2/test_plot.py
@@ -5,7 +5,7 @@ from tests.base.D2.test_d2 import TestD2
 class DrawTest(TestD2):
 
     def test_plot(self):
-        fc = self.frame.get_chns(xy=True, hsv=True)
+        fc = self.frame.get_chns(self_=False, chns=[self.frame.CHN.XY, self.frame.CHN.HSV])
 
         fpl = fc.plot()
         ROWS = 3

--- a/tests/base/D2/test_score.py
+++ b/tests/base/D2/test_score.py
@@ -3,6 +3,7 @@ import unittest
 from sklearn.cluster import KMeans
 from sklearn.preprocessing import minmax_scale
 
+from frmodel.base import CONSTS
 from frmodel.base.D2 import Frame2D
 from frmodel.base.D2.kmeans2D import KMeans2D
 from tests.base.D2.test_d2 import TestD2
@@ -11,8 +12,12 @@ from tests.base.D2.test_d2 import TestD2
 class ScoreTest(TestD2):
 
     def test_box(self):
+        C = CONSTS.CHN
+
         f = Frame2D.from_image(self._RSC + "/imgs/basic/box.png")
-        frame_xy = f.get_chns(xy=True, hsv=True, mex_g=True, ex_gr=True, ndi=True)
+        # frame_xy = f.get_chns(xy=True, hsv=True, mex_g=True, ex_gr=True, ndi=True)
+        frame_xy = f.get_chns(self_=False,
+                              chns=[C.XY, C.HSV, C.MEX_G, C.EX_GR, C.NDI])
 
         km = KMeans2D(frame_xy,
                       KMeans(n_clusters=3, verbose=False),


### PR DESCRIPTION
# Motivation

Because we are going to be dealing with many more channels, a good structure must be present to seamlessly integrate those extra channels without exponentially increasing technical debt 

## Key Changes

For ``Frame2D``, data will still be stored the same, that is ``Frame2D.data`` will still return the same array as before this version. The difference is that there's a ``label`` property that holds the channel names.

Take for example, if `Frame2D` is holding RGB data, the label would be ``('R','G','B')``. The labels, should represent the channel dimension in the ``.data`` property.

This implementation will not feature back-compatibility as it's too much band-aid code.

## New Calling Conventions for ``get_chns`` (Non-GLCM)

``Frame2D.get_chns()`` now only accepts arguments where ``chns`` accepts ``List[str]``. it is highly recommended to use the constants provided within ``Frame2D`` or ``consts.py`` for consistency of string validation.

```
f.get_chns(self_=True, chns=[f.CHN.XY, f.CHN.HSV]) # Recommended
f.get_chns(self_=True, chns=[("X","Y"), ("H","S","V")]) # Not Recommended but still valid
```

Note that ``self_`` means to include current channels.

There are some special cases where you can't get individual channels. This is done to optimize speed.
```
f.get_chns(self_=True, chns=[f.CHN.X]) # Not Valid, must always use XY then slice
f.get_chns(self_=True, chns=[f.CHN.SATURATION]) # Not Valid, must always use HSV then slice
```

Base values such as RGB cannot be used as they are the source of calculations/base values.
```
f.get_chns(self_=True, chns=[f.CHN.RGB]) # Not Valid, cannot calculate base values
```

## New Calling Conventions ``get_chns`` (GLCM)

GLCM has gone under overhaul also, calling glcm through ``get_chns`` requires the ``GLCM`` class as required.

The major change from this is that GLCM is now not limited to RGB, it will work with any channel as long as the calculation turns out valid.

For example:

```
glcm = Frame2D.GLCM(by_x=1,by_y=1,radius=5,
       contrast=[f.CHN.RGB],
       correlation=[f.CHN.MEX_G,f.CHN.NDI],
       entropy=[f.CHN.RGB])

f.get_chns(self_=True, glcm=glcm)
```

**Note that if you call entropy with non-RGB channels, you may get useless values**

```
glcm = Frame2D.GLCM(by_x=1,by_y=1,radius=5,
       entropy=[f.CHN.MEX_G])

f.get_chns(self_=True, glcm=glcm)
```

This is because entropy here is discrete, whereas most channel/indexes are continuous, it would require a separate implementation of a continuous entropy algorithm not yet implemented.

## New Calling Conventions for ``data_chn``

For ``data_chn``, now it has been converted into a consistent index grabbing algorithm. That is, you don't need to memorize which index each channel is on, you just need to fill in the indexes.

```
f_0 = f.data_chn([f.CHN.RED, f.CHN.HSV])
f_0.labels
>> {'R': 0, 'H': 1, 'S': 2, 'V': 3}
```

This will create another ``Frame2D`` for f_0, such that it has the channels R, H, S, V. This has now been changed to return ``Frame2D``, so if you need to access the ndarray, call ``.data``.









